### PR TITLE
Implement S10 backend timer foundation

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GameSessionController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GameSessionController.java
@@ -70,4 +70,12 @@ public class GameSessionController {
         Long userId = body.get("userId");
         return gameSessionService.startGame(code, userId);
     }
+
+    @PostMapping("/{code}/finish")
+    @ResponseStatus(HttpStatus.OK)
+    @ResponseBody
+    public SessionGetDTO finishGame(@PathVariable String code, @RequestBody Map<String, Long> body) {
+        Long userId = body.get("userId");
+        return gameSessionService.finishGame(code, userId);
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/GameSession.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/GameSession.java
@@ -38,6 +38,12 @@ public class GameSession implements Serializable {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
+    @Column
+    private LocalDateTime startedAt;
+
+    @Column
+    private LocalDateTime finishedAt;
+
     @Column(columnDefinition = "TEXT")
     private String problemsJson;
 
@@ -64,6 +70,12 @@ public class GameSession implements Serializable {
 
     public LocalDateTime getCreatedAt() { return createdAt; }
     public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+
+    public LocalDateTime getStartedAt() { return startedAt; }
+    public void setStartedAt(LocalDateTime startedAt) { this.startedAt = startedAt; }
+
+    public LocalDateTime getFinishedAt() { return finishedAt; }
+    public void setFinishedAt(LocalDateTime finishedAt) { this.finishedAt = finishedAt; }
 
     public String getProblemsJson() { return problemsJson; }
     public void setProblemsJson(String problemsJson) { this.problemsJson = problemsJson; }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionGetDTO.java
@@ -12,6 +12,9 @@ public class SessionGetDTO {
     private String status;
     private LocalDateTime createdAt;
     private LocalDateTime expiresAt;
+    private LocalDateTime startedAt;
+    private LocalDateTime finishedAt;
+    private Long elapsedSeconds;
 
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
@@ -33,4 +36,13 @@ public class SessionGetDTO {
 
     public LocalDateTime getExpiresAt() { return expiresAt; }
     public void setExpiresAt(LocalDateTime expiresAt) { this.expiresAt = expiresAt; }
+
+    public LocalDateTime getStartedAt() { return startedAt; }
+    public void setStartedAt(LocalDateTime startedAt) { this.startedAt = startedAt; }
+
+    public LocalDateTime getFinishedAt() { return finishedAt; }
+    public void setFinishedAt(LocalDateTime finishedAt) { this.finishedAt = finishedAt; }
+
+    public Long getElapsedSeconds() { return elapsedSeconds; }
+    public void setElapsedSeconds(Long elapsedSeconds) { this.elapsedSeconds = elapsedSeconds; }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameSessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameSessionService.java
@@ -13,6 +13,7 @@ import ch.uzh.ifi.hase.soprafs26.repository.GameSessionRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionGetDTO;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -93,12 +94,40 @@ public class GameSessionService {
         if (session.getJoinerId() == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Need two players to start the game");
         }
+        if (session.getStartedAt() == null) {
+            session.setStartedAt(LocalDateTime.now());
+        }
         session.setStatus(SessionStatus.ACTIVE);
         sessionRepository.flush();
 
         SessionGetDTO dto = convertToDTO(session);
         messagingTemplate.convertAndSend("/topic/session/" + code, dto);
         return dto;
+    }
+
+    public SessionGetDTO finishGame(String code, Long userId) {
+        GameSession session = findSession(code);
+
+        if (!isParticipant(session, userId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only session participants can finish the game");
+        }
+        if (session.getStatus() == SessionStatus.CANCELLED) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Cancelled sessions cannot be finished");
+        }
+        if (session.getStartedAt() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Session has not started yet");
+        }
+
+        if (session.getFinishedAt() == null) {
+            session.setFinishedAt(LocalDateTime.now());
+            sessionRepository.flush();
+
+            SessionGetDTO dto = convertToDTO(session);
+            messagingTemplate.convertAndSend("/topic/session/" + code, dto);
+            return dto;
+        }
+
+        return convertToDTO(session);
     }
 
     public void saveProblems(String code, String problemsJson) {
@@ -151,6 +180,11 @@ public class GameSessionService {
         }
     }
 
+    private boolean isParticipant(GameSession session, Long userId) {
+        return session.getCreatorId().equals(userId)
+                || (session.getJoinerId() != null && session.getJoinerId().equals(userId));
+    }
+
     private String generateUniqueCode() {
         String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
         Random random = new Random();
@@ -173,6 +207,9 @@ public class GameSessionService {
         dto.setStatus(session.getStatus().name());
         dto.setCreatedAt(session.getCreatedAt());
         dto.setExpiresAt(session.getCreatedAt().plusMinutes(5));
+        dto.setStartedAt(session.getStartedAt());
+        dto.setFinishedAt(session.getFinishedAt());
+        dto.setElapsedSeconds(calculateElapsedSeconds(session));
 
         List<String> players = new ArrayList<>();
         players.add(session.getCreatorUsername());
@@ -182,5 +219,14 @@ public class GameSessionService {
         dto.setPlayers(players);
 
         return dto;
+    }
+
+    private Long calculateElapsedSeconds(GameSession session) {
+        if (session.getStartedAt() == null) {
+            return null;
+        }
+
+        LocalDateTime endTime = session.getFinishedAt() != null ? session.getFinishedAt() : LocalDateTime.now();
+        return Math.max(0, Duration.between(session.getStartedAt(), endTime).getSeconds());
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameSessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameSessionServiceTest.java
@@ -20,6 +20,9 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class GameSessionServiceTest {
@@ -158,5 +161,85 @@ public class GameSessionServiceTest {
         assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
         assertEquals(SessionStatus.CANCELLED, session.getStatus());
         Mockito.verify(sessionRepository, Mockito.times(1)).flush();
+    }
+
+    @Test
+    public void startGame_setsStartedAtAndReturnsElapsedSeconds() {
+        session.setJoinerId(joiner.getId());
+        session.setJoinerUsername(joiner.getUsername());
+        Mockito.when(sessionRepository.findByCode(session.getCode())).thenReturn(session);
+
+        SessionGetDTO result = gameSessionService.startGame(session.getCode(), creator.getId());
+
+        assertEquals(SessionStatus.ACTIVE, session.getStatus());
+        assertNotNull(session.getStartedAt());
+        assertNotNull(result.getStartedAt());
+        assertNull(result.getFinishedAt());
+        assertNotNull(result.getElapsedSeconds());
+        assertTrue(result.getElapsedSeconds() >= 0);
+        Mockito.verify(sessionRepository, Mockito.times(1)).flush();
+    }
+
+    @Test
+    public void getSession_startedSessionReturnsNonNegativeElapsedSeconds() {
+        LocalDateTime startedAt = LocalDateTime.now().minusSeconds(12);
+        session.setStatus(SessionStatus.ACTIVE);
+        session.setStartedAt(startedAt);
+        Mockito.when(sessionRepository.findByCode(session.getCode())).thenReturn(session);
+
+        SessionGetDTO result = gameSessionService.getSession(session.getCode());
+
+        assertEquals(startedAt, result.getStartedAt());
+        assertNull(result.getFinishedAt());
+        assertNotNull(result.getElapsedSeconds());
+        assertTrue(result.getElapsedSeconds() >= 12);
+    }
+
+    @Test
+    public void finishGame_setsFinishedAtAndFreezesElapsedSeconds() {
+        LocalDateTime startedAt = LocalDateTime.now().minusSeconds(30);
+        session.setJoinerId(joiner.getId());
+        session.setJoinerUsername(joiner.getUsername());
+        session.setStatus(SessionStatus.ACTIVE);
+        session.setStartedAt(startedAt);
+        Mockito.when(sessionRepository.findByCode(session.getCode())).thenReturn(session);
+
+        SessionGetDTO firstResult = gameSessionService.finishGame(session.getCode(), joiner.getId());
+        SessionGetDTO secondResult = gameSessionService.finishGame(session.getCode(), joiner.getId());
+
+        assertNotNull(session.getFinishedAt());
+        assertNotNull(firstResult.getFinishedAt());
+        assertNotNull(firstResult.getElapsedSeconds());
+        assertEquals(firstResult.getFinishedAt(), secondResult.getFinishedAt());
+        assertEquals(firstResult.getElapsedSeconds(), secondResult.getElapsedSeconds());
+    }
+
+    @Test
+    public void finishGame_nonParticipant_throwsForbidden() {
+        User outsider = new User();
+        outsider.setId(3L);
+        session.setJoinerId(joiner.getId());
+        session.setJoinerUsername(joiner.getUsername());
+        session.setStatus(SessionStatus.ACTIVE);
+        session.setStartedAt(LocalDateTime.now().minusSeconds(10));
+        Mockito.when(sessionRepository.findByCode(session.getCode())).thenReturn(session);
+
+        ResponseStatusException exception =
+                assertThrows(ResponseStatusException.class, () -> gameSessionService.finishGame(session.getCode(), outsider.getId()));
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+    }
+
+    @Test
+    public void finishGame_beforeStart_throwsBadRequest() {
+        session.setJoinerId(joiner.getId());
+        session.setJoinerUsername(joiner.getUsername());
+        session.setStatus(SessionStatus.WAITING);
+        Mockito.when(sessionRepository.findByCode(session.getCode())).thenReturn(session);
+
+        ResponseStatusException exception =
+                assertThrows(ResponseStatusException.class, () -> gameSessionService.finishGame(session.getCode(), creator.getId()));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
     }
 }


### PR DESCRIPTION
## Summary
Implements the backend timer foundation for S10 by extending session data with timer timestamps, exposing elapsed-time fields in the session DTO, starting the timer on session start, and adding a participant-only finish endpoint that freezes the elapsed time.

## Issues
- #10

## What changed
- added `startedAt` and `finishedAt` to `GameSession`
- exposed `startedAt`, `finishedAt`, and `elapsedSeconds` in the session response DTO
- set `startedAt` when `/sessions/{code}/start` succeeds
- added `POST /sessions/{code}/finish` for participants to freeze the timer
- added focused `GameSessionServiceTest` coverage for timer start, elapsed time, finish freeze, repeated finish, non-participant rejection, and finish-before-start rejection

## Verification
- `./gradlew compileJava` passed
- `./gradlew test --tests ch.uzh.ifi.hase.soprafs26.service.GameSessionServiceTest` is still blocked by unrelated pre-existing compile failures in legacy `User*` tests that reference removed `name`/`findByName` APIs

## Out of scope
- no unrelated user test infrastructure fixes
- no broader session lifecycle redesign beyond timer support