### PR TITLE
Fix legacy User tests for current username model and SonarCloud coverage

### DIFF
--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
@@ -54,7 +54,6 @@ public class UserControllerTest {
 	public void givenUsers_whenGetUsers_thenReturnJsonArray() throws Exception {
 		// given
 		User user = new User();
-		user.setName("Firstname Lastname");
 		user.setUsername("firstname@lastname");
 		user.setStatus(UserStatus.OFFLINE);
 
@@ -70,7 +69,6 @@ public class UserControllerTest {
 		// then
 		mockMvc.perform(getRequest).andExpect(status().isOk())
 				.andExpect(jsonPath("$", hasSize(1)))
-				.andExpect(jsonPath("$[0].name", is(user.getName())))
 				.andExpect(jsonPath("$[0].username", is(user.getUsername())))
 				.andExpect(jsonPath("$[0].status", is(user.getStatus().toString())));
 	}
@@ -80,14 +78,13 @@ public class UserControllerTest {
 		// given
 		User user = new User();
 		user.setId(1L);
-		user.setName("Test User");
 		user.setUsername("testUsername");
 		user.setToken("1");
 		user.setStatus(UserStatus.ONLINE);
 
 		UserPostDTO userPostDTO = new UserPostDTO();
-		userPostDTO.setName("Test User");
 		userPostDTO.setUsername("testUsername");
+		userPostDTO.setPassword("password123");
 
 		given(userService.createUser(Mockito.any())).willReturn(user);
 
@@ -100,7 +97,6 @@ public class UserControllerTest {
 		mockMvc.perform(postRequest)
 				.andExpect(status().isCreated())
 				.andExpect(jsonPath("$.id", is(user.getId().intValue())))
-				.andExpect(jsonPath("$.name", is(user.getName())))
 				.andExpect(jsonPath("$.username", is(user.getUsername())))
 				.andExpect(jsonPath("$.status", is(user.getStatus().toString())));
 	}
@@ -122,7 +118,6 @@ public class UserControllerTest {
 	public void loginUser_validInput_returns200() throws Exception {
 		User user = new User();
 		user.setId(1L);
-		user.setName("Test User");
 		user.setUsername("testUsername");
 		user.setPassword("password123");
 		user.setToken("1");
@@ -141,7 +136,6 @@ public class UserControllerTest {
 		mockMvc.perform(postRequest)
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.id", is(user.getId().intValue())))
-				.andExpect(jsonPath("$.name", is(user.getName())))
 				.andExpect(jsonPath("$.username", is(user.getUsername())))
 				.andExpect(jsonPath("$.status", is(user.getStatus().toString())))
 				.andExpect(jsonPath("$.token", is(user.getToken())));
@@ -151,7 +145,6 @@ public class UserControllerTest {
 	public void getUserProfile_validInput_returns200() throws Exception {
 		User user = new User();
 		user.setId(1L);
-		user.setName("Test User");
 		user.setUsername("testUsername");
 		user.setStatus(UserStatus.ONLINE);
 		user.setHighestScore(25);
@@ -177,7 +170,8 @@ public class UserControllerTest {
 	/**
 	 * Helper Method to convert userPostDTO into a JSON string such that the input
 	 * can be processed
-	 * Input will look like this: {"name": "Test User", "username": "testUsername"}
+	 * Input will look like this:
+	 * {"username": "testUsername", "password": "password123"}
 	 * 
 	 * @param object
 	 * @return string

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepositoryIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepositoryIntegrationTest.java
@@ -1,5 +1,7 @@
 package ch.uzh.ifi.hase.soprafs26.repository;
 
+import java.time.LocalDate;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
@@ -21,24 +23,23 @@ public class UserRepositoryIntegrationTest {
 	private UserRepository userRepository;
 
 	@Test
-	public void findByName_success() {
+	public void findByUsername_success() {
 		// given
 		User user = new User();
-		user.setName("Firstname Lastname");
 		user.setUsername("firstname@lastname");
 		user.setPassword("password123");
 		user.setStatus(UserStatus.OFFLINE);
 		user.setToken("1");
+		user.setCreationDate(LocalDate.now());
 
 		entityManager.persist(user);
 		entityManager.flush();
 
 		// when
-		User found = userRepository.findByName(user.getName());
+		User found = userRepository.findByUsername(user.getUsername());
 
 		// then
 		assertNotNull(found.getId());
-		assertEquals(found.getName(), user.getName());
 		assertEquals(found.getUsername(), user.getUsername());
 		assertEquals(found.getToken(), user.getToken());
 		assertEquals(found.getStatus(), user.getStatus());

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapperTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapperTest.java
@@ -19,22 +19,21 @@ public class DTOMapperTest {
 	public void testCreateUser_fromUserPostDTO_toUser_success() {
 		// create UserPostDTO
 		UserPostDTO userPostDTO = new UserPostDTO();
-		userPostDTO.setName("name");
 		userPostDTO.setUsername("username");
+		userPostDTO.setPassword("password123");
 
 		// MAP -> Create user
 		User user = DTOMapper.INSTANCE.convertUserPostDTOtoEntity(userPostDTO);
 
 		// check content
-		assertEquals(userPostDTO.getName(), user.getName());
 		assertEquals(userPostDTO.getUsername(), user.getUsername());
+		assertEquals(userPostDTO.getPassword(), user.getPassword());
 	}
 
 	@Test
 	public void testGetUser_fromUser_toUserGetDTO_success() {
 		// create User
 		User user = new User();
-		user.setName("Firstname Lastname");
 		user.setUsername("firstname@lastname");
 		user.setStatus(UserStatus.OFFLINE);
 		user.setToken("1");
@@ -44,7 +43,6 @@ public class DTOMapperTest {
 
 		// check content
 		assertEquals(user.getId(), userGetDTO.getId());
-		assertEquals(user.getName(), userGetDTO.getName());
 		assertEquals(user.getUsername(), userGetDTO.getUsername());
 		assertEquals(user.getStatus(), userGetDTO.getStatus());
 	}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceIntegrationTest.java
@@ -41,7 +41,6 @@ public class UserServiceIntegrationTest {
 		assertNull(userRepository.findByUsername("testUsername"));
 
 		User testUser = new User();
-		testUser.setName("testName");
 		testUser.setUsername("testUsername");
 		testUser.setPassword("password123");
 
@@ -50,7 +49,6 @@ public class UserServiceIntegrationTest {
 
 		// then
 		assertEquals(testUser.getId(), createdUser.getId());
-		assertEquals(testUser.getName(), createdUser.getName());
 		assertEquals(testUser.getUsername(), createdUser.getUsername());
 		assertNotNull(createdUser.getToken());
 		assertEquals(UserStatus.ONLINE, createdUser.getStatus());
@@ -61,7 +59,6 @@ public class UserServiceIntegrationTest {
 		assertNull(userRepository.findByUsername("testUsername"));
 
 		User testUser = new User();
-		testUser.setName("testName");
 		testUser.setUsername("testUsername");
 		testUser.setPassword("password123");
 		userService.createUser(testUser);
@@ -69,8 +66,6 @@ public class UserServiceIntegrationTest {
 		// attempt to create second user with same username
 		User testUser2 = new User();
 
-		// change the name but forget about the username
-		testUser2.setName("testName2");
 		testUser2.setUsername("testUsername");
 		testUser2.setPassword("password456");
 
@@ -81,7 +76,6 @@ public class UserServiceIntegrationTest {
 	@Test
 	public void loginUser_validCredentials_success() {
 		User testUser = new User();
-		testUser.setName("testName");
 		testUser.setUsername("testUsername");
 		testUser.setPassword("password123");
 		userService.createUser(testUser);
@@ -95,7 +89,6 @@ public class UserServiceIntegrationTest {
 	@Test
 	public void loginUser_invalidPassword_throwsException() {
 		User testUser = new User();
-		testUser.setName("testName");
 		testUser.setUsername("testUsername");
 		testUser.setPassword("password123");
 		userService.createUser(testUser);
@@ -106,7 +99,6 @@ public class UserServiceIntegrationTest {
 	@Test
 	public void getUserProfile_existingUser_success() {
 		User testUser = new User();
-		testUser.setName("testName");
 		testUser.setUsername("testUsername");
 		testUser.setPassword("password123");
 		User createdUser = userService.createUser(testUser);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceTest.java
@@ -34,8 +34,8 @@ public class UserServiceTest {
 		// given
 		testUser = new User();
 		testUser.setId(1L);
-		testUser.setName("testName");
 		testUser.setUsername("testUsername");
+		testUser.setPassword("password123");
 
 		// when -> any object is being save in the userRepository -> return the dummy
 		// testUser
@@ -52,7 +52,6 @@ public class UserServiceTest {
 		Mockito.verify(userRepository, Mockito.times(1)).save(Mockito.any());
 
 		assertEquals(testUser.getId(), createdUser.getId());
-		assertEquals(testUser.getName(), createdUser.getName());
 		assertEquals(testUser.getUsername(), createdUser.getUsername());
 		assertNotNull(createdUser.getToken());
 		assertEquals(UserStatus.ONLINE, createdUser.getStatus());
@@ -69,30 +68,9 @@ public class UserServiceTest {
 	}
 
 	@Test
-	public void createUser_duplicateName_throwsException() {
-		// given -> a first user has already been created
-		userService.createUser(testUser);
-
-		// when -> setup additional mocks for UserRepository
-		Mockito.when(userRepository.findByName(Mockito.any())).thenReturn(testUser);
-		Mockito.when(userRepository.findByUsername(Mockito.any())).thenReturn(null);
-
-		// then -> attempt to create second user with same user -> check that an error
-		// is thrown
-		assertThrows(ResponseStatusException.class, () -> userService.createUser(testUser));
-	}
-
-	@Test
-	public void createUser_duplicateInputs_throwsException() {
-		// given -> a first user has already been created
-		userService.createUser(testUser);
-
-		// when -> setup additional mocks for UserRepository
-		Mockito.when(userRepository.findByName(Mockito.any())).thenReturn(testUser);
+	public void createUser_duplicateUsername_throwsException() {
 		Mockito.when(userRepository.findByUsername(Mockito.any())).thenReturn(testUser);
 
-		// then -> attempt to create second user with same user -> check that an error
-		// is thrown
 		assertThrows(ResponseStatusException.class, () -> userService.createUser(testUser));
 	}
 


### PR DESCRIPTION
## Summary
Fixes legacy backend User tests that still referenced `name`, `getName`, `setName`, and `findByName`, while the current backend model uses `username`, `getUsername`, `setUsername`, and `findByUsername`.

## Issues
- #100

## Why this matters
The backend GitHub Action currently fails before SonarCloud can refresh coverage. This unblocks `./gradlew test jacocoTestReport sonar` so the current M3 server coverage can be measured.

## Verification
- `./gradlew compileTestJava`
- `./gradlew clean test jacocoTestReport`
- local JaCoCo report regenerated with 63% instruction coverage and 55% branch coverage