### PR TITLE
#78 #79 #80 Implement S16 backend summary endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ server-runtime.log
 server-runtime.err.log
 *.DS_STORE
 .direnv
+.env*
+!.envrc
 
 # don't track the local.properties -> contains secrets
 local.properties

--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ More Information about [Gradle Wrapper](https://docs.gradle.org/current/userguid
 
 You can verify that the server is running by visiting `localhost:8080` in your browser.
 
+### OpenRouter game summaries
+
+The S16 game summary endpoint can call OpenRouter from the backend only. Configure secrets as runtime environment variables, not in committed files:
+
+```powershell
+$env:OPENROUTER_API_KEY="new-key-here"
+$env:OPENROUTER_MODEL="openrouter/free"
+```
+
+`OPENROUTER_MODEL` defaults to `openrouter/free` when omitted. If `OPENROUTER_API_KEY` is missing or OpenRouter is unavailable, the backend returns deterministic fallback feedback and still saves score/time stats.
+
 ### Test
 
 ```bash

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GameSessionController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GameSessionController.java
@@ -4,9 +4,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import ch.uzh.ifi.hase.soprafs26.rest.dto.ProblemsDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.GameSummaryGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.GameSummaryPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionJoinPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionPostDTO;
+import ch.uzh.ifi.hase.soprafs26.service.GameSummaryService;
 import ch.uzh.ifi.hase.soprafs26.service.GameSessionService;
 
 import java.util.Map;
@@ -16,9 +19,11 @@ import java.util.Map;
 public class GameSessionController {
 
     private final GameSessionService gameSessionService;
+    private final GameSummaryService gameSummaryService;
 
-    public GameSessionController(GameSessionService gameSessionService) {
+    public GameSessionController(GameSessionService gameSessionService, GameSummaryService gameSummaryService) {
         this.gameSessionService = gameSessionService;
+        this.gameSummaryService = gameSummaryService;
     }
 
     @PostMapping
@@ -77,5 +82,12 @@ public class GameSessionController {
     public SessionGetDTO finishGame(@PathVariable String code, @RequestBody Map<String, Long> body) {
         Long userId = body.get("userId");
         return gameSessionService.finishGame(code, userId);
+    }
+
+    @PostMapping("/{code}/summary")
+    @ResponseStatus(HttpStatus.OK)
+    @ResponseBody
+    public GameSummaryGetDTO createSummary(@PathVariable String code, @RequestBody GameSummaryPostDTO summaryPostDTO) {
+        return gameSummaryService.createSummary(code, summaryPostDTO);
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GameSummaryGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GameSummaryGetDTO.java
@@ -1,0 +1,33 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class GameSummaryGetDTO {
+
+    private Integer score;
+    private Long elapsedSeconds;
+    private Boolean newHighscore;
+    private String feedback;
+    private Integer totalScore;
+    private Integer highestScore;
+    private Long timePlayed;
+
+    public Integer getScore() { return score; }
+    public void setScore(Integer score) { this.score = score; }
+
+    public Long getElapsedSeconds() { return elapsedSeconds; }
+    public void setElapsedSeconds(Long elapsedSeconds) { this.elapsedSeconds = elapsedSeconds; }
+
+    public Boolean getNewHighscore() { return newHighscore; }
+    public void setNewHighscore(Boolean newHighscore) { this.newHighscore = newHighscore; }
+
+    public String getFeedback() { return feedback; }
+    public void setFeedback(String feedback) { this.feedback = feedback; }
+
+    public Integer getTotalScore() { return totalScore; }
+    public void setTotalScore(Integer totalScore) { this.totalScore = totalScore; }
+
+    public Integer getHighestScore() { return highestScore; }
+    public void setHighestScore(Integer highestScore) { this.highestScore = highestScore; }
+
+    public Long getTimePlayed() { return timePlayed; }
+    public void setTimePlayed(Long timePlayed) { this.timePlayed = timePlayed; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GameSummaryPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GameSummaryPostDTO.java
@@ -1,0 +1,21 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class GameSummaryPostDTO {
+
+    private Long userId;
+    private Integer score;
+    private Long elapsedSeconds;
+    private Integer livesRemaining;
+
+    public Long getUserId() { return userId; }
+    public void setUserId(Long userId) { this.userId = userId; }
+
+    public Integer getScore() { return score; }
+    public void setScore(Integer score) { this.score = score; }
+
+    public Long getElapsedSeconds() { return elapsedSeconds; }
+    public void setElapsedSeconds(Long elapsedSeconds) { this.elapsedSeconds = elapsedSeconds; }
+
+    public Integer getLivesRemaining() { return livesRemaining; }
+    public void setLivesRemaining(Integer livesRemaining) { this.livesRemaining = livesRemaining; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameSummaryService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameSummaryService.java
@@ -1,0 +1,117 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.constant.SessionStatus;
+import ch.uzh.ifi.hase.soprafs26.entity.GameSession;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.repository.GameSessionRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.GameSummaryGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.GameSummaryPostDTO;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+
+@Service
+@Transactional
+public class GameSummaryService {
+
+    private final GameSessionRepository sessionRepository;
+    private final UserRepository userRepository;
+    private final OpenRouterSummaryService openRouterSummaryService;
+
+    public GameSummaryService(
+            GameSessionRepository sessionRepository,
+            UserRepository userRepository,
+            OpenRouterSummaryService openRouterSummaryService) {
+        this.sessionRepository = sessionRepository;
+        this.userRepository = userRepository;
+        this.openRouterSummaryService = openRouterSummaryService;
+    }
+
+    public GameSummaryGetDTO createSummary(String code, GameSummaryPostDTO request) {
+        if (request == null || request.getUserId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Missing userId");
+        }
+
+        GameSession session = findSession(code);
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+
+        validateSummarizableSession(session, user.getId());
+
+        int score = sanitizeScore(request.getScore());
+        long elapsedSeconds = sanitizeElapsedSeconds(request.getElapsedSeconds());
+        int livesRemaining = sanitizeLivesRemaining(request.getLivesRemaining());
+
+        if (session.getFinishedAt() == null) {
+            session.setFinishedAt(LocalDateTime.now());
+        }
+
+        int previousHighscore = user.getHighestScore() == null ? 0 : user.getHighestScore();
+        int previousTotalScore = user.getTotalScore() == null ? 0 : user.getTotalScore();
+        long previousTimePlayed = user.getTimePlayed() == null ? 0L : user.getTimePlayed();
+        boolean newHighscore = score > previousHighscore;
+
+        if (newHighscore) {
+            user.setHighestScore(score);
+        }
+        user.setTotalScore(previousTotalScore + score);
+        user.setTimePlayed(previousTimePlayed + elapsedSeconds);
+
+        sessionRepository.flush();
+        userRepository.flush();
+
+        String feedback = openRouterSummaryService.generateFeedback(
+                score,
+                elapsedSeconds,
+                livesRemaining,
+                newHighscore
+        );
+
+        GameSummaryGetDTO response = new GameSummaryGetDTO();
+        response.setScore(score);
+        response.setElapsedSeconds(elapsedSeconds);
+        response.setNewHighscore(newHighscore);
+        response.setFeedback(feedback);
+        response.setTotalScore(user.getTotalScore());
+        response.setHighestScore(user.getHighestScore());
+        response.setTimePlayed(user.getTimePlayed());
+        return response;
+    }
+
+    private GameSession findSession(String code) {
+        GameSession session = sessionRepository.findByCode(code);
+        if (session == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Session with code '" + code + "' not found");
+        }
+        return session;
+    }
+
+    private void validateSummarizableSession(GameSession session, Long userId) {
+        if (session.getStatus() == SessionStatus.CANCELLED) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Cancelled sessions cannot be summarized");
+        }
+        if (session.getStartedAt() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Session has not started yet");
+        }
+        if (!session.getCreatorId().equals(userId)
+                && (session.getJoinerId() == null || !session.getJoinerId().equals(userId))) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only session participants can summarize the game");
+        }
+    }
+
+    private int sanitizeScore(Integer score) {
+        return Math.max(0, score == null ? 0 : score);
+    }
+
+    private long sanitizeElapsedSeconds(Long elapsedSeconds) {
+        return Math.max(0L, elapsedSeconds == null ? 0L : elapsedSeconds);
+    }
+
+    private int sanitizeLivesRemaining(Integer livesRemaining) {
+        return Math.max(0, livesRemaining == null ? 0 : livesRemaining);
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/OpenRouterClient.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/OpenRouterClient.java
@@ -1,0 +1,5 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+public interface OpenRouterClient {
+    String createFeedback(String apiKey, String model, String prompt, int maxTokens) throws Exception;
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/OpenRouterHttpClient.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/OpenRouterHttpClient.java
@@ -1,0 +1,66 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class OpenRouterHttpClient implements OpenRouterClient {
+
+    private static final URI CHAT_COMPLETIONS_URI = URI.create("https://openrouter.ai/api/v1/chat/completions");
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    public OpenRouterHttpClient() {
+        this(HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build(), new ObjectMapper());
+    }
+
+    OpenRouterHttpClient(HttpClient httpClient, ObjectMapper objectMapper) {
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public String createFeedback(String apiKey, String model, String prompt, int maxTokens) throws Exception {
+        Map<String, Object> payload = Map.of(
+                "model", model,
+                "max_tokens", maxTokens,
+                "temperature", 0.4,
+                "messages", List.of(
+                        Map.of(
+                                "role", "system",
+                                "content", "You write short encouraging Math Invaders end-game feedback. Return one concise sentence, max 35 words. Do not mention being AI."),
+                        Map.of("role", "user", "content", prompt)
+                )
+        );
+
+        HttpRequest request = HttpRequest.newBuilder(CHAT_COMPLETIONS_URI)
+                .timeout(Duration.ofSeconds(10))
+                .header("Authorization", "Bearer " + apiKey)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new IOException("OpenRouter request failed with status " + response.statusCode());
+        }
+
+        JsonNode root = objectMapper.readTree(response.body());
+        String content = root.path("choices").path(0).path("message").path("content").asText("").trim();
+        if (content.isBlank()) {
+            throw new IOException("OpenRouter response did not include feedback content");
+        }
+
+        return content;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/OpenRouterSummaryService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/OpenRouterSummaryService.java
@@ -1,0 +1,80 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OpenRouterSummaryService {
+
+    private static final String DEFAULT_MODEL = "openrouter/free";
+    private static final int MAX_TOKENS = 160;
+
+    private final OpenRouterClient openRouterClient;
+    private final String apiKey;
+    private final String model;
+
+    public OpenRouterSummaryService(
+            OpenRouterClient openRouterClient,
+            @Value("${OPENROUTER_API_KEY:}") String apiKey,
+            @Value("${OPENROUTER_MODEL:openrouter/free}") String model) {
+        this.openRouterClient = openRouterClient;
+        this.apiKey = apiKey;
+        this.model = normalizeModel(model);
+    }
+
+    public String generateFeedback(int score, long elapsedSeconds, int livesRemaining, boolean newHighscore) {
+        if (apiKey == null || apiKey.isBlank()) {
+            return fallbackFeedback(score, elapsedSeconds);
+        }
+
+        try {
+            String feedback = openRouterClient.createFeedback(
+                    apiKey,
+                    model,
+                    buildPrompt(score, elapsedSeconds, livesRemaining, newHighscore),
+                    MAX_TOKENS
+            );
+            if (feedback == null || feedback.isBlank()) {
+                return fallbackFeedback(score, elapsedSeconds);
+            }
+            return feedback.trim();
+        } catch (Exception error) {
+            if (error instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            return fallbackFeedback(score, elapsedSeconds);
+        }
+    }
+
+    String fallbackFeedback(int score, long elapsedSeconds) {
+        return String.format(
+                "Great run. You scored %d points in %s. Keep focusing on fast factor recognition and avoiding risky shots.",
+                score,
+                formatDuration(elapsedSeconds)
+        );
+    }
+
+    private String buildPrompt(int score, long elapsedSeconds, int livesRemaining, boolean newHighscore) {
+        return String.format(
+                "Write short Math Invaders feedback for a player. Score: %d. Time: %s. Lives remaining: %d. New highscore: %s.",
+                score,
+                formatDuration(elapsedSeconds),
+                livesRemaining,
+                newHighscore ? "yes" : "no"
+        );
+    }
+
+    private String formatDuration(long elapsedSeconds) {
+        long safeSeconds = Math.max(0, elapsedSeconds);
+        long minutes = safeSeconds / 60;
+        long seconds = safeSeconds % 60;
+        return String.format("%02d:%02d", minutes, seconds);
+    }
+
+    private String normalizeModel(String configuredModel) {
+        if (configuredModel == null || configuredModel.isBlank()) {
+            return DEFAULT_MODEL;
+        }
+        return configuredModel.trim();
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/GameSessionControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/GameSessionControllerTest.java
@@ -1,0 +1,68 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import ch.uzh.ifi.hase.soprafs26.rest.dto.GameSummaryGetDTO;
+import ch.uzh.ifi.hase.soprafs26.service.GameSessionService;
+import ch.uzh.ifi.hase.soprafs26.service.GameSummaryService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(GameSessionController.class)
+public class GameSessionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private GameSessionService gameSessionService;
+
+    @MockitoBean
+    private GameSummaryService gameSummaryService;
+
+    @Test
+    public void createSummary_validRequest_returnsSummaryJson() throws Exception {
+        GameSummaryGetDTO response = new GameSummaryGetDTO();
+        response.setScore(42);
+        response.setElapsedSeconds(93L);
+        response.setNewHighscore(true);
+        response.setFeedback("Great run.");
+        response.setTotalScore(180);
+        response.setHighestScore(42);
+        response.setTimePlayed(930L);
+
+        given(gameSummaryService.createSummary(eq("ABC123"), any())).willReturn(response);
+
+        mockMvc.perform(post("/sessions/ABC123/summary")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": 1,
+                                  "score": 42,
+                                  "elapsedSeconds": 93,
+                                  "livesRemaining": 1
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.score", is(42)))
+                .andExpect(jsonPath("$.elapsedSeconds", is(93)))
+                .andExpect(jsonPath("$.newHighscore", is(true)))
+                .andExpect(jsonPath("$.feedback", is("Great run.")))
+                .andExpect(jsonPath("$.totalScore", is(180)))
+                .andExpect(jsonPath("$.highestScore", is(42)))
+                .andExpect(jsonPath("$.timePlayed", is(930)));
+
+        Mockito.verify(gameSummaryService).createSummary(eq("ABC123"), any());
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameSummaryServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameSummaryServiceTest.java
@@ -1,0 +1,130 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.constant.SessionStatus;
+import ch.uzh.ifi.hase.soprafs26.entity.GameSession;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.repository.GameSessionRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.GameSummaryGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.GameSummaryPostDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GameSummaryServiceTest {
+
+    private GameSessionRepository sessionRepository;
+    private UserRepository userRepository;
+    private OpenRouterSummaryService openRouterSummaryService;
+    private GameSummaryService gameSummaryService;
+    private GameSession session;
+    private User user;
+
+    @BeforeEach
+    public void setup() {
+        sessionRepository = Mockito.mock(GameSessionRepository.class);
+        userRepository = Mockito.mock(UserRepository.class);
+        openRouterSummaryService = Mockito.mock(OpenRouterSummaryService.class);
+        gameSummaryService = new GameSummaryService(sessionRepository, userRepository, openRouterSummaryService);
+
+        session = new GameSession();
+        session.setId(1L);
+        session.setCode("ABC123");
+        session.setCreatorId(1L);
+        session.setCreatorUsername("host");
+        session.setJoinerId(2L);
+        session.setJoinerUsername("guest");
+        session.setStatus(SessionStatus.ACTIVE);
+        session.setCreatedAt(LocalDateTime.now().minusMinutes(2));
+        session.setStartedAt(LocalDateTime.now().minusSeconds(93));
+
+        user = new User();
+        user.setId(1L);
+        user.setUsername("host");
+        user.setHighestScore(30);
+        user.setTotalScore(138);
+        user.setTimePlayed(837L);
+
+        Mockito.when(sessionRepository.findByCode("ABC123")).thenReturn(session);
+        Mockito.when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        Mockito.when(openRouterSummaryService.generateFeedback(Mockito.anyInt(), Mockito.anyLong(), Mockito.anyInt(), Mockito.anyBoolean()))
+                .thenReturn("Generated feedback.");
+    }
+
+    @Test
+    public void createSummary_higherScoreUpdatesHighscoreAndStats() {
+        GameSummaryPostDTO request = summaryRequest(1L, 42, 93L, 1);
+
+        GameSummaryGetDTO result = gameSummaryService.createSummary("ABC123", request);
+
+        assertTrue(result.getNewHighscore());
+        assertEquals(42, result.getHighestScore());
+        assertEquals(180, result.getTotalScore());
+        assertEquals(930L, result.getTimePlayed());
+        assertEquals("Generated feedback.", result.getFeedback());
+        assertNotNull(session.getFinishedAt());
+        Mockito.verify(sessionRepository).flush();
+        Mockito.verify(userRepository).flush();
+        Mockito.verify(openRouterSummaryService).generateFeedback(42, 93L, 1, true);
+    }
+
+    @Test
+    public void createSummary_equalScoreDoesNotSetNewHighscore() {
+        user.setHighestScore(42);
+        user.setTotalScore(10);
+        user.setTimePlayed(20L);
+        GameSummaryPostDTO request = summaryRequest(1L, 42, 10L, 0);
+
+        GameSummaryGetDTO result = gameSummaryService.createSummary("ABC123", request);
+
+        assertFalse(result.getNewHighscore());
+        assertEquals(42, result.getHighestScore());
+        assertEquals(52, result.getTotalScore());
+        assertEquals(30L, result.getTimePlayed());
+    }
+
+    @Test
+    public void createSummary_nonParticipantThrowsForbidden() {
+        User outsider = new User();
+        outsider.setId(3L);
+        Mockito.when(userRepository.findById(3L)).thenReturn(Optional.of(outsider));
+        GameSummaryPostDTO request = summaryRequest(3L, 12, 30L, 0);
+
+        ResponseStatusException exception =
+                assertThrows(ResponseStatusException.class, () -> gameSummaryService.createSummary("ABC123", request));
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        Mockito.verifyNoInteractions(openRouterSummaryService);
+    }
+
+    @Test
+    public void createSummary_cancelledSessionThrowsConflict() {
+        session.setStatus(SessionStatus.CANCELLED);
+        GameSummaryPostDTO request = summaryRequest(1L, 12, 30L, 0);
+
+        ResponseStatusException exception =
+                assertThrows(ResponseStatusException.class, () -> gameSummaryService.createSummary("ABC123", request));
+
+        assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
+    }
+
+    private GameSummaryPostDTO summaryRequest(Long userId, Integer score, Long elapsedSeconds, Integer livesRemaining) {
+        GameSummaryPostDTO request = new GameSummaryPostDTO();
+        request.setUserId(userId);
+        request.setScore(score);
+        request.setElapsedSeconds(elapsedSeconds);
+        request.setLivesRemaining(livesRemaining);
+        return request;
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/OpenRouterSummaryServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/OpenRouterSummaryServiceTest.java
@@ -1,0 +1,60 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OpenRouterSummaryServiceTest {
+
+    @Test
+    public void generateFeedback_missingApiKey_returnsFallbackWithoutCallingClient() throws Exception {
+        OpenRouterClient client = Mockito.mock(OpenRouterClient.class);
+        OpenRouterSummaryService service = new OpenRouterSummaryService(client, "", "openrouter/free");
+
+        String feedback = service.generateFeedback(42, 93L, 1, true);
+
+        assertEquals(
+                "Great run. You scored 42 points in 01:33. Keep focusing on fast factor recognition and avoiding risky shots.",
+                feedback
+        );
+        Mockito.verifyNoInteractions(client);
+    }
+
+    @Test
+    public void generateFeedback_blankModelDefaultsToFreeRouter() throws Exception {
+        OpenRouterClient client = Mockito.mock(OpenRouterClient.class);
+        Mockito.when(client.createFeedback(Mockito.eq("secret"), Mockito.eq("openrouter/free"), Mockito.anyString(), Mockito.eq(160)))
+                .thenReturn("Strong finish with sharp factor recognition.");
+        OpenRouterSummaryService service = new OpenRouterSummaryService(client, "secret", " ");
+
+        String feedback = service.generateFeedback(12, 61L, 2, false);
+
+        assertEquals("Strong finish with sharp factor recognition.", feedback);
+    }
+
+    @Test
+    public void generateFeedback_openRouterThrows_returnsFallback() throws Exception {
+        OpenRouterClient client = Mockito.mock(OpenRouterClient.class);
+        Mockito.when(client.createFeedback(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt()))
+                .thenThrow(new RuntimeException("rate limited"));
+        OpenRouterSummaryService service = new OpenRouterSummaryService(client, "secret", "openrouter/free");
+
+        String feedback = service.generateFeedback(7, 5L, 0, false);
+
+        assertTrue(feedback.contains("You scored 7 points in 00:05"));
+    }
+
+    @Test
+    public void generateFeedback_emptyOpenRouterContent_returnsFallback() throws Exception {
+        OpenRouterClient client = Mockito.mock(OpenRouterClient.class);
+        Mockito.when(client.createFeedback(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt()))
+                .thenReturn("  ");
+        OpenRouterSummaryService service = new OpenRouterSummaryService(client, "secret", "openrouter/free");
+
+        String feedback = service.generateFeedback(3, 120L, 0, false);
+
+        assertTrue(feedback.contains("You scored 3 points in 02:00"));
+    }
+}


### PR DESCRIPTION
## Summary
Implements the backend S16 game-summary endpoint with backend-only OpenRouter support.

## Included
- `POST /sessions/{code}/summary`
- score, highscore, totalScore, and timePlayed update logic
- OpenRouter feedback generation using `openrouter/free`
- deterministic fallback feedback when OpenRouter is unavailable
- tests for stats, highscore logic, participant validation, fallback behavior, and controller response

## Security
- no API key committed
- OpenRouter key is read only from `OPENROUTER_API_KEY`
- model defaults to `openrouter/free`

## Verification
- `./gradlew.bat test` passes