### PR TITLE
M4: Prevent duplicate game-summary submissions

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/GameSession.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/GameSession.java
@@ -47,6 +47,12 @@ public class GameSession implements Serializable {
     @Column(columnDefinition = "TEXT")
     private String problemsJson;
 
+    @Column(nullable = false, columnDefinition = "boolean default false")
+    private boolean creatorSummarySubmitted = false;
+
+    @Column(nullable = false, columnDefinition = "boolean default false")
+    private boolean joinerSummarySubmitted = false;
+
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
 
@@ -79,4 +85,14 @@ public class GameSession implements Serializable {
 
     public String getProblemsJson() { return problemsJson; }
     public void setProblemsJson(String problemsJson) { this.problemsJson = problemsJson; }
+
+    public boolean isCreatorSummarySubmitted() { return creatorSummarySubmitted; }
+    public void setCreatorSummarySubmitted(boolean creatorSummarySubmitted) {
+        this.creatorSummarySubmitted = creatorSummarySubmitted;
+    }
+
+    public boolean isJoinerSummarySubmitted() { return joinerSummarySubmitted; }
+    public void setJoinerSummarySubmitted(boolean joinerSummarySubmitted) {
+        this.joinerSummarySubmitted = joinerSummarySubmitted;
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameSummaryService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameSummaryService.java
@@ -41,6 +41,7 @@ public class GameSummaryService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
 
         validateSummarizableSession(session, user.getId());
+        rejectDuplicateSubmission(session, user.getId());
 
         int score = sanitizeScore(request.getScore());
         long elapsedSeconds = sanitizeElapsedSeconds(request.getElapsedSeconds());
@@ -60,6 +61,7 @@ public class GameSummaryService {
         }
         user.setTotalScore(previousTotalScore + score);
         user.setTimePlayed(previousTimePlayed + elapsedSeconds);
+        markSummarySubmitted(session, user.getId());
 
         sessionRepository.flush();
         userRepository.flush();
@@ -101,6 +103,32 @@ public class GameSummaryService {
                 && (session.getJoinerId() == null || !session.getJoinerId().equals(userId))) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only session participants can summarize the game");
         }
+    }
+
+    private void rejectDuplicateSubmission(GameSession session, Long userId) {
+        if (isCreator(session, userId) && session.isCreatorSummarySubmitted()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Summary already submitted for this user and session");
+        }
+        if (isJoiner(session, userId) && session.isJoinerSummarySubmitted()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Summary already submitted for this user and session");
+        }
+    }
+
+    private void markSummarySubmitted(GameSession session, Long userId) {
+        if (isCreator(session, userId)) {
+            session.setCreatorSummarySubmitted(true);
+        }
+        else if (isJoiner(session, userId)) {
+            session.setJoinerSummarySubmitted(true);
+        }
+    }
+
+    private boolean isCreator(GameSession session, Long userId) {
+        return session.getCreatorId().equals(userId);
+    }
+
+    private boolean isJoiner(GameSession session, Long userId) {
+        return session.getJoinerId() != null && session.getJoinerId().equals(userId);
     }
 
     private int sanitizeScore(Integer score) {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameSummaryServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameSummaryServiceTest.java
@@ -74,6 +74,8 @@ public class GameSummaryServiceTest {
         assertEquals(930L, result.getTimePlayed());
         assertEquals("Generated feedback.", result.getFeedback());
         assertNotNull(session.getFinishedAt());
+        assertTrue(session.isCreatorSummarySubmitted());
+        assertFalse(session.isJoinerSummarySubmitted());
         Mockito.verify(sessionRepository).flush();
         Mockito.verify(userRepository).flush();
         Mockito.verify(openRouterSummaryService).generateFeedback(42, 93L, 1, true);
@@ -92,6 +94,46 @@ public class GameSummaryServiceTest {
         assertEquals(42, result.getHighestScore());
         assertEquals(52, result.getTotalScore());
         assertEquals(30L, result.getTimePlayed());
+    }
+
+    @Test
+    public void createSummary_duplicateSubmissionThrowsConflictWithoutUpdatingStats() {
+        session.setCreatorSummarySubmitted(true);
+        LocalDateTime previousFinishedAt = session.getFinishedAt();
+        GameSummaryPostDTO request = summaryRequest(1L, 99, 120L, 3);
+
+        ResponseStatusException exception =
+                assertThrows(ResponseStatusException.class, () -> gameSummaryService.createSummary("ABC123", request));
+
+        assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
+        assertEquals(30, user.getHighestScore());
+        assertEquals(138, user.getTotalScore());
+        assertEquals(837L, user.getTimePlayed());
+        assertEquals(previousFinishedAt, session.getFinishedAt());
+        assertTrue(session.isCreatorSummarySubmitted());
+        Mockito.verify(sessionRepository, Mockito.never()).flush();
+        Mockito.verify(userRepository, Mockito.never()).flush();
+        Mockito.verifyNoInteractions(openRouterSummaryService);
+    }
+
+    @Test
+    public void createSummary_joinerFirstSubmissionMarksJoinerOnly() {
+        User joiner = new User();
+        joiner.setId(2L);
+        joiner.setUsername("guest");
+        joiner.setHighestScore(8);
+        joiner.setTotalScore(20);
+        joiner.setTimePlayed(60L);
+        Mockito.when(userRepository.findById(2L)).thenReturn(Optional.of(joiner));
+        GameSummaryPostDTO request = summaryRequest(2L, 12, 30L, 0);
+
+        GameSummaryGetDTO result = gameSummaryService.createSummary("ABC123", request);
+
+        assertTrue(result.getNewHighscore());
+        assertFalse(session.isCreatorSummarySubmitted());
+        assertTrue(session.isJoinerSummarySubmitted());
+        assertEquals(32, joiner.getTotalScore());
+        assertEquals(90L, joiner.getTimePlayed());
     }
 
     @Test
@@ -117,6 +159,18 @@ public class GameSummaryServiceTest {
                 assertThrows(ResponseStatusException.class, () -> gameSummaryService.createSummary("ABC123", request));
 
         assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
+    }
+
+    @Test
+    public void createSummary_unstartedSessionThrowsBadRequest() {
+        session.setStartedAt(null);
+        GameSummaryPostDTO request = summaryRequest(1L, 12, 30L, 0);
+
+        ResponseStatusException exception =
+                assertThrows(ResponseStatusException.class, () -> gameSummaryService.createSummary("ABC123", request));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        Mockito.verifyNoInteractions(openRouterSummaryService);
     }
 
     private GameSummaryPostDTO summaryRequest(Long userId, Integer score, Long elapsedSeconds, Integer livesRemaining) {


### PR DESCRIPTION
## Summary
- Track per-session creator/joiner summary submissions
- Reject duplicate summaries with 409 CONFLICT before mutating profile stats or generating feedback
- Add service tests for first submissions, duplicate submissions, non-participants, cancelled sessions, and unstarted sessions

Closes #119.

## Validation
- `SPRING_DATASOURCE_URL=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1 ./gradlew test` passed
- Plain `./gradlew test` fails locally because H2 2.4 rejects the existing file datasource option combination `AUTO_SERVER=TRUE` with `DB_CLOSE_ON_EXIT=FALSE` in this environment