### PR TITLE
M4: Fix backend test datasource for CI

### DIFF
--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1


### PR DESCRIPTION
## Summary
- Add test-only datasource configuration under `src/test/resources`
- Use in-memory H2 for tests: `jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1`
- Avoid the main runtime H2 file URL option combination that fails in CI/test runs

Closes #121.

## Validation
- `./gradlew test` passed locally without any environment override