### PR TITLE
fix: make game summary endpoint reliable

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameSummaryService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameSummaryService.java
@@ -9,26 +9,28 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.GameSummaryGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GameSummaryPostDTO;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 
 @Service
-@Transactional
 public class GameSummaryService {
 
     private final GameSessionRepository sessionRepository;
     private final UserRepository userRepository;
     private final OpenRouterSummaryService openRouterSummaryService;
+    private final TransactionTemplate transactionTemplate;
 
     public GameSummaryService(
             GameSessionRepository sessionRepository,
             UserRepository userRepository,
-            OpenRouterSummaryService openRouterSummaryService) {
+            OpenRouterSummaryService openRouterSummaryService,
+            TransactionTemplate transactionTemplate) {
         this.sessionRepository = sessionRepository;
         this.userRepository = userRepository;
         this.openRouterSummaryService = openRouterSummaryService;
+        this.transactionTemplate = transactionTemplate;
     }
 
     public GameSummaryGetDTO createSummary(String code, GameSummaryPostDTO request) {
@@ -36,6 +38,30 @@ public class GameSummaryService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Missing userId");
         }
 
+        SummaryPersistenceResult result = transactionTemplate.execute(status -> persistSummary(code, request));
+        if (result == null) {
+            throw new IllegalStateException("Summary persistence did not return a result");
+        }
+
+        String feedback = openRouterSummaryService.generateFeedback(
+                result.score(),
+                result.elapsedSeconds(),
+                result.livesRemaining(),
+                result.newHighscore()
+        );
+
+        GameSummaryGetDTO response = new GameSummaryGetDTO();
+        response.setScore(result.score());
+        response.setElapsedSeconds(result.elapsedSeconds());
+        response.setNewHighscore(result.newHighscore());
+        response.setFeedback(feedback);
+        response.setTotalScore(result.totalScore());
+        response.setHighestScore(result.highestScore());
+        response.setTimePlayed(result.timePlayed());
+        return response;
+    }
+
+    private SummaryPersistenceResult persistSummary(String code, GameSummaryPostDTO request) {
         GameSession session = findSession(code);
         User user = userRepository.findById(request.getUserId())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
@@ -66,22 +92,15 @@ public class GameSummaryService {
         sessionRepository.flush();
         userRepository.flush();
 
-        String feedback = openRouterSummaryService.generateFeedback(
+        return new SummaryPersistenceResult(
                 score,
                 elapsedSeconds,
                 livesRemaining,
-                newHighscore
+                newHighscore,
+                user.getTotalScore(),
+                user.getHighestScore(),
+                user.getTimePlayed()
         );
-
-        GameSummaryGetDTO response = new GameSummaryGetDTO();
-        response.setScore(score);
-        response.setElapsedSeconds(elapsedSeconds);
-        response.setNewHighscore(newHighscore);
-        response.setFeedback(feedback);
-        response.setTotalScore(user.getTotalScore());
-        response.setHighestScore(user.getHighestScore());
-        response.setTimePlayed(user.getTimePlayed());
-        return response;
     }
 
     private GameSession findSession(String code) {
@@ -141,5 +160,15 @@ public class GameSummaryService {
 
     private int sanitizeLivesRemaining(Integer livesRemaining) {
         return Math.max(0, livesRemaining == null ? 0 : livesRemaining);
+    }
+
+    private record SummaryPersistenceResult(
+            int score,
+            long elapsedSeconds,
+            int livesRemaining,
+            boolean newHighscore,
+            int totalScore,
+            int highestScore,
+            long timePlayed) {
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/GameSummaryIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/GameSummaryIntegrationTest.java
@@ -1,0 +1,195 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import ch.uzh.ifi.hase.soprafs26.repository.GameSessionRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class GameSummaryIntegrationTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GameSessionRepository sessionRepository;
+
+    @BeforeEach
+    public void setup() {
+        sessionRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    public void createSummary_fullSessionFlow_returns200ThenDuplicate409() throws Exception {
+        Long creatorId = createUser("creator");
+        Long joinerId = createUser("joiner");
+        String code = createJoinedStartedSession(creatorId, joinerId);
+
+        mockMvc.perform(post("/sessions/{code}/summary", code)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": %d,
+                                  "score": 42,
+                                  "elapsedSeconds": 93,
+                                  "livesRemaining": 1
+                                }
+                                """.formatted(creatorId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.score", is(42)))
+                .andExpect(jsonPath("$.elapsedSeconds", is(93)))
+                .andExpect(jsonPath("$.newHighscore", is(true)))
+                .andExpect(jsonPath("$.highestScore", is(42)))
+                .andExpect(jsonPath("$.totalScore", is(42)))
+                .andExpect(jsonPath("$.timePlayed", is(93)));
+
+        mockMvc.perform(post("/sessions/{code}/summary", code)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": %d,
+                                  "score": 99,
+                                  "elapsedSeconds": 120,
+                                  "livesRemaining": 3
+                                }
+                                """.formatted(creatorId)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.detail", is("Summary already submitted for this user and session")));
+    }
+
+    @Test
+    public void createSummary_unstartedSession_returns400() throws Exception {
+        Long creatorId = createUser("creator");
+        String code = createSession(creatorId);
+
+        mockMvc.perform(post("/sessions/{code}/summary", code)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(summaryJson(creatorId)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.detail", is("Session has not started yet")));
+    }
+
+    @Test
+    public void createSummary_nonParticipant_returns403() throws Exception {
+        Long creatorId = createUser("creator");
+        Long joinerId = createUser("joiner");
+        Long outsiderId = createUser("outsider");
+        String code = createJoinedStartedSession(creatorId, joinerId);
+
+        mockMvc.perform(post("/sessions/{code}/summary", code)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(summaryJson(outsiderId)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.detail", is("Only session participants can summarize the game")));
+    }
+
+    @Test
+    public void createSummary_missingSession_returns404() throws Exception {
+        Long creatorId = createUser("creator");
+
+        mockMvc.perform(post("/sessions/MISSING/summary")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(summaryJson(creatorId)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.detail", is("Session with code 'MISSING' not found")));
+    }
+
+    @Test
+    public void createSummary_missingUser_returns404() throws Exception {
+        Long creatorId = createUser("creator");
+        Long joinerId = createUser("joiner");
+        String code = createJoinedStartedSession(creatorId, joinerId);
+
+        mockMvc.perform(post("/sessions/{code}/summary", code)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(summaryJson(999999L)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.detail", is("User not found")));
+    }
+
+    private Long createUser(String username) throws Exception {
+        MvcResult result = mockMvc.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "%s",
+                                  "password": "secret123"
+                                }
+                                """.formatted(username)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return readJson(result).path("id").asLong();
+    }
+
+    private String createJoinedStartedSession(Long creatorId, Long joinerId) throws Exception {
+        String code = createSession(creatorId);
+
+        mockMvc.perform(post("/sessions/{code}/join", code)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": %d
+                                }
+                                """.formatted(joinerId)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/sessions/{code}/start", code)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": %d
+                                }
+                                """.formatted(creatorId)))
+                .andExpect(status().isOk());
+
+        return code;
+    }
+
+    private String createSession(Long creatorId) throws Exception {
+        MvcResult result = mockMvc.perform(post("/sessions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "creatorId": %d
+                                }
+                                """.formatted(creatorId)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return readJson(result).path("code").asString();
+    }
+
+    private String summaryJson(Long userId) {
+        return """
+                {
+                  "userId": %d,
+                  "score": 12,
+                  "elapsedSeconds": 30,
+                  "livesRemaining": 0
+                }
+                """.formatted(userId);
+    }
+
+    private JsonNode readJson(MvcResult result) throws Exception {
+        return objectMapper.readTree(result.getResponse().getContentAsString());
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameSummaryServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameSummaryServiceTest.java
@@ -11,6 +11,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
@@ -27,6 +30,7 @@ public class GameSummaryServiceTest {
     private GameSessionRepository sessionRepository;
     private UserRepository userRepository;
     private OpenRouterSummaryService openRouterSummaryService;
+    private TransactionTemplate transactionTemplate;
     private GameSummaryService gameSummaryService;
     private GameSession session;
     private User user;
@@ -36,7 +40,17 @@ public class GameSummaryServiceTest {
         sessionRepository = Mockito.mock(GameSessionRepository.class);
         userRepository = Mockito.mock(UserRepository.class);
         openRouterSummaryService = Mockito.mock(OpenRouterSummaryService.class);
-        gameSummaryService = new GameSummaryService(sessionRepository, userRepository, openRouterSummaryService);
+        transactionTemplate = Mockito.mock(TransactionTemplate.class);
+        Mockito.when(transactionTemplate.execute(Mockito.any())).thenAnswer(invocation -> {
+            TransactionCallback<?> callback = invocation.getArgument(0);
+            return callback.doInTransaction(Mockito.mock(TransactionStatus.class));
+        });
+        gameSummaryService = new GameSummaryService(
+                sessionRepository,
+                userRepository,
+                openRouterSummaryService,
+                transactionTemplate
+        );
 
         session = new GameSession();
         session.setId(1L);


### PR DESCRIPTION
This fixes the live summary-endpoint reliability issue by separating database persistence from OpenRouter feedback generation. The first valid summary now persists stats and idempotency state before the external feedback call. Duplicate summaries still return 409, invalid game states return the expected 400/403/404 responses, and OpenRouter fallback behaviour remains intact.

SoPra traceability:
Closes #128

Tests:
- `.\gradlew.bat test`
- Added REST integration tests for first summary, duplicate summary, unstarted session, non-participant, missing session and missing user.